### PR TITLE
Migrate from Poetry to uv and add AI agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,129 @@
+# SEAD Clearinghouse Import - AI Agent Instructions
+
+## Project Purpose
+Python system that transforms Excel data submissions into XML/CSV formats conforming to the SEAD ClearingHouse database schema, then uploads and processes them into PostgreSQL staging/public tables.
+
+## Architecture Overview
+
+### Core Workflow (3-stage pipeline)
+1. **Load & Transform**: Excel → `Submission` object (via policies) → validated data
+2. **Dispatch**: `Submission` → XML/CSV (via `IDispatcher` implementations)  
+3. **Upload & Process**: Files → DB staging tables → explode to public schema
+
+### Key Components
+- **`Submission`** ([submission.py](../importer/submission.py)): Wrapper for Excel data tables loaded as pandas DataFrames
+- **`Metadata`** ([metadata.py](../importer/metadata.py)): Database schema metadata (tables, columns, FKs, PKs) queried from PostgreSQL `information_schema`
+- **`Policies`** ([policies.py](../importer/policies.py)): Auto-registered data transformation rules applied to submissions (see Registry pattern below)
+- **`Specifications`** ([specification.py](../importer/specification.py)): Validation rules for data integrity
+- **`ImportService`** ([process.py](../importer/process.py)): Orchestrates the full workflow
+
+### Data Model Conventions
+- **`system_id`**: Internal temporary ID used during submission (required on all tables, must be unique per table)
+- **`pk_name`**: The actual public database primary key (e.g., `site_id`, `dataset_id`)
+- **New vs Existing Records**: Rows with null `pk_name` are new; non-null means updating existing records
+- **Lookup Tables**: Small reference tables (e.g., `tbl_sample_types`) managed specially by policies
+
+## Critical Patterns
+
+### Registry Pattern
+Policies and Specifications auto-register using decorators:
+```python
+@UpdatePolicies.register()
+class AddPrimaryKeyColumnIfMissingPolicy(PolicyBase):
+    def update(self) -> None:
+        # Transformation logic here
+```
+- Policies execute in **priority order** (configured in `config.yml`)
+- Can be disabled per-policy in config: `policies.<policy_id>.disabled: true`
+- Policy IDs are snake_case class names (e.g., `add_primary_key_column_if_missing_policy`)
+
+### Configuration Injection
+Uses custom dependency injection via `ConfigValue` (see [inject.py](../importer/configuration/inject.py)):
+```python
+class Options:
+    ignore_columns: list[str] = ConfigValue("options:ignore_columns").resolve()
+```
+**Priority order**: CLI args → options file → environment vars (`SEAD_IMPORT_*`) → YAML config
+
+Configuration files: 
+- Project-wide: [config.yml](../config.yml)
+- Data-specific: [data/config.yml](../data/config.yml)
+
+## Developer Workflows
+
+### Running Import
+```bash
+# Standard workflow with all stages
+PYTHONPATH=. python importer/scripts/import_excel.py \
+  config.yml data/input/file.xlsx \
+  --name "submission_name" \
+  --output-folder output/ \
+  --register --explode
+
+# Check-only mode (validation without XML generation)
+PYTHONPATH=. python importer/scripts/import_excel.py config.yml file.xlsx --check-only
+
+# Using existing submission ID
+PYTHONPATH=. python importer/scripts/import_excel.py config.yml 123 --name "existing"
+```
+
+### Testing
+```bash
+make test           # Fast tests (excludes @pytest.mark.long_running)
+make full-test      # All tests including long-running
+make test-coverage  # With HTML coverage report
+```
+
+### Code Quality
+```bash
+make tidy          # black + isort (line-length=120)
+make lint          # pylint across importer/ and tests/
+```
+
+### Environment Setup
+- Requires Python 3.12 (use pyenv)
+- uv for dependency management (install: `curl -LsSf https://astral.sh/uv/install.sh | sh`)
+- External dependency: `tidy` CLI tool for XML formatting (`sudo apt-get install tidy`)
+- Database credentials in `.env` or passed via CLI
+- Run `uv sync` to install dependencies
+
+## Common Gotchas
+
+### Excel File Requirements
+- Must be `.xlsx` format (Excel 2007+)
+- Each table requires a sheet with exact name matching metadata `excel_sheet` field
+- Column names must match database schema (case-sensitive)
+- Required columns: `system_id` (can be added by policy) + `pk_name` for the table
+
+### Policy Execution
+- Policies modify `Submission.data_tables` in-place
+- Order matters! Check `config.yml` for priority settings
+- Common policies:
+  - `AddPrimaryKeyColumnIfMissingPolicy`: Adds PK column with nulls (assumes all new records)
+  - `IfForeignKeyValueIsMissingAddIdentityMappingToForeignKeyTable`: Auto-creates referenced lookup records
+  - `DropIgnoredColumns`: Removes columns matching patterns in `ignore_columns` config
+
+### Foreign Key Management
+- FK references use `system_id` during submission, not public PK values
+- FK table must be included in submission or already exist in database
+- Missing FK references can trigger auto-creation of lookup entries (depending on policy config)
+
+## File Locations
+
+### Input/Output
+- Excel inputs: `data/<domain>/` (e.g., `data/dendro/`, `data/ceramics/`)
+- Generated XML/CSV: `output/` (timestamped filenames by default)
+- Logs: `logs/` (YAML format with timestamp prefix)
+
+### Key Source Modules
+- Entry point: [importer/scripts/import_excel.py](../importer/scripts/import_excel.py)
+- Dispatchers: [importer/dispatchers/](../importer/dispatchers/) (XML generation logic)
+- Uploaders: [importer/uploader/](../importer/uploader/) (DB interaction)
+- Tests: [tests/](../tests/) (includes test submissions in `tests/submissions/`)
+
+## Code Style Specifics
+- Black formatting: 120 char line length, skip string normalization
+- Use `loguru` for logging (not stdlib logging)
+- Dataclasses preferred for config/options objects
+- Type hints required (Python 3.12 syntax)
+- Pandas DataFrames are primary data structure for table manipulation

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# uv
+.venv/
+uv.lock
+.python-version
+
 # C extensions
 *.so
 

--- a/MIGRATION_UV.md
+++ b/MIGRATION_UV.md
@@ -1,0 +1,121 @@
+# Migration from Poetry to uv
+
+This document summarizes the migration from Poetry to uv for the SEAD Clearinghouse Import project.
+
+## What Changed
+
+### Package Management
+- **Before**: Poetry (`poetry.lock`)
+- **After**: uv (`uv.lock`)
+
+### Configuration Files
+
+#### pyproject.toml
+- Converted from Poetry's `[tool.poetry]` format to standard PEP 621 `[project]` format
+- Changed build backend from `poetry-core` to `hatchling`
+- Added `[tool.hatch.build.targets.wheel]` to specify package location
+- Converted dependency specifications:
+  - `python = "3.12.*"` → `requires-python = ">=3.12"`
+  - `package = "^1.2.3"` → `package>=1.2.3"`
+- Changed `psycopg2` to `psycopg2-binary` to avoid compilation issues
+
+#### Makefile
+Updated all Poetry commands to uv equivalents:
+- `poetry install` → `uv sync --all-extras`
+- `poetry run <cmd>` → `uv run <cmd>`
+- `poetry build` → `uv build`
+- `poetry publish` → `uv publish`
+- `poetry version patch` → `uv version patch`
+- `poetry cache clear` → `uv cache clean`
+- `poetry export` → `uv pip compile`
+
+#### .gitignore
+Updated to ignore uv-specific files:
+- Added `.venv/`
+- Added `uv.lock`
+- Added `.python-version`
+
+### Documentation Updates
+- Updated README.md installation instructions
+- Updated .github/copilot-instructions.md
+
+## Command Equivalents
+
+| Poetry Command | uv Equivalent |
+|---------------|---------------|
+| `poetry install` | `uv sync` or `make install` |
+| `poetry add <package>` | `uv add <package>` |
+| `poetry remove <package>` | `uv remove <package>` |
+| `poetry run <command>` | `uv run <command>` |
+| `poetry shell` | `source .venv/bin/activate` |
+| `poetry lock` | `uv lock` |
+| `poetry update` | `uv sync --upgrade` |
+
+## Developer Workflow Changes
+
+### Initial Setup
+```bash
+# Install uv if not already installed
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone and setup
+git clone git@github.com:humlab-sead/sead_clearinghouse_import
+cd sead_clearinghouse_import
+uv sync  # or make install
+```
+
+### Running Tests
+```bash
+make test           # Fast tests
+make full-test      # All tests
+make test-coverage  # With coverage
+```
+
+### Code Quality
+```bash
+make tidy          # black + isort
+make lint          # pylint
+```
+
+### Running Scripts
+```bash
+# Using uv run directly
+uv run python importer/scripts/import_excel.py --help
+
+# Or using the virtual environment
+source .venv/bin/activate
+python importer/scripts/import_excel.py --help
+```
+
+## Benefits of uv
+
+1. **Speed**: Much faster dependency resolution and installation
+2. **Drop-in replacement**: Works with existing PEP 621 pyproject.toml
+3. **No additional configuration**: Uses standard Python packaging formats
+4. **Better caching**: More efficient disk usage
+5. **Active development**: Maintained by Astral (makers of Ruff)
+
+## Migration Checklist
+
+- [x] Convert pyproject.toml to PEP 621 format
+- [x] Update build backend to hatchling
+- [x] Update Makefile commands
+- [x] Update README.md
+- [x] Update .gitignore
+- [x] Update .github/copilot-instructions.md
+- [x] Generate uv.lock file
+- [x] Verify make targets work
+- [x] Test that dev tools work (pytest, black, pylint)
+
+## Rollback (if needed)
+
+If you need to rollback to Poetry:
+1. `git checkout main -- pyproject.toml Makefile README.md .gitignore`
+2. `poetry install`
+3. Delete `.venv` and `uv.lock` if created by uv
+
+## Notes
+
+- The old `poetry.lock` file is still in the repository but is no longer used
+- uv creates its virtual environment in `.venv/` by default (same as Poetry)
+- All existing make targets continue to work with the same syntax

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ PACKAGE_FOLDER=importer
 
 RUN_TIMESTAMP := $(shell /bin/date "+%Y-%m-%d-%H%M%S")
 
+.PHONY: install
+install:
+	@uv sync --all-extras
+
 fast-release: clean tidy build guard_clean_working_repository bump.patch tag publish
 
 release: ready guard_clean_working_repository bump.patch tag  publish
@@ -12,10 +16,10 @@ release: ready guard_clean_working_repository bump.patch tag  publish
 ready: tools clean tidy full-test lint build
 
 build: requirements.txt
-	@poetry build
+	@uv build
 
 publish:
-	@poetry publish
+	@uv publish
 
 lint: tidy pylint flake8
 
@@ -23,35 +27,35 @@ tidy: black isort
 
 test: output-dir
 	@echo SKIPPING LONG RUNNING TESTS!
-	@poetry run pytest -m "not long_running" --durations=0 tests
+	@uv run pytest -m "not long_running" --durations=0 tests
 	@rm -rf ./tests/output/*
 
 pytest: output-dir
-	@poetry run pytest -m "not long_running" --durations=0 tests
+	@uv run pytest -m "not long_running" --durations=0 tests
 
 test-coverage: output-dir
 	@echo SKIPPING LONG RUNNING TESTS!
-	@poetry run pytest -m "not long_running" --cov=$(PACKAGE_FOLDER) --cov-report=html tests
+	@uv run pytest -m "not long_running" --cov=$(PACKAGE_FOLDER) --cov-report=html tests
 	@rm -rf ./tests/output/*
 
 full-test: output-dir
-	@poetry run pytest tests
+	@uv run pytest tests
 	@rm -rf ./tests/output/*
 
 long-test: output-dir
-	@poetry run pytest -m "long_running" --durations=0 tests
+	@uv run pytest -m "long_running" --durations=0 tests
 	@rm -rf ./tests/output/*
 
 full-test-coverage: output-dir
 	@mkdir -p ./tests/output
-	@poetry run pytest --cov=$(PACKAGE_FOLDER) --cov-report=html tests
+	@uv run pytest --cov=$(PACKAGE_FOLDER) --cov-report=html tests
 	@rm -rf ./tests/output/*
 
 output-dir:
 	@mkdir -p ./tests/output ./logs
 
 retest:
-	@poetry run pytest --durations=0 --last-failed tests
+	@uv run pytest --durations=0 --last-failed tests
 
 .ONESHELL: guard_clean_working_repository
 guard_clean_working_repository:
@@ -68,27 +72,27 @@ bump.patch: bump.version.patch sync.package.version
 	@git push
 
 bump.version.patch:
-	@poetry version patch
+	@uv version patch
 
 .PHONY: tag
 tag:
-	@poetry build
+	@uv build
 	@git push
 	@git tag $(shell grep "^version \= " pyproject.toml | sed "s/version = //" | sed "s/\"//g") -a
 	@git push origin --tags
 
 .PHONY: pylint
 pylint:
-	@time poetry run pylint $(SOURCE_FOLDERS)
-	# @poetry run mypy --version
-	# @poetry run mypy .
+	@time uv run pylint $(SOURCE_FOLDERS)
+	# @uv run mypy --version
+	# @uv run mypy .
 
 isort:
-	@poetry run isort --profile black --float-to-top --line-length 120 --py 311 $(SOURCE_FOLDERS)
+	@uv run isort --profile black --float-to-top --line-length 120 --py auto $(SOURCE_FOLDERS)
 
 black: clean
-	@poetry run black --version
-	@poetry run black  $(SOURCE_FOLDERS)
+	@uv run black --version
+	@uv run black  $(SOURCE_FOLDERS)
 
 clean:
 	@rm -rf .pytest_cache build dist .eggs *.egg-info
@@ -99,10 +103,10 @@ clean:
 	@rm -rf tests/output
 
 clean_cache:
-	@poetry cache clear pypi --all
+	@uv cache clean
 
-requirements.txt: poetry.lock
-	@poetry export --without-hashes -f requirements.txt --output requirements.txt
+requirements.txt: uv.lock
+	@uv pip compile pyproject.toml -o requirements.txt
 
 .PHONY: help check install version
 .PHONY: lint flake8 pylint pylint_by_file yapf black isort tidy pylint_diff_only
@@ -112,7 +116,7 @@ requirements.txt: poetry.lock
 
 venus:
 	# @tar czvf ./tmp/VENUS.$(RUN_TIMESTAMP).tar.gz ./tests/test_data/VENUS
-	@poetry run python -c 'from tests.pipeline.fixtures import create_test_data_bundles; create_test_data_bundles()'
+	@uv run python -c 'from tests.pipeline.fixtures import create_test_data_bundles; create_test_data_bundles()'
 
 help:
 	@echo "Higher level recepies: "

--- a/README.md
+++ b/README.md
@@ -9,14 +9,19 @@ This program uses `tidlib` to cleanup the resulting XML which you can install us
 sudo apt-get install tidy
 ```
 
-You will need Python ^3.12 (install with pyenv) and Poetry on your local machine.
+You will need Python ^3.12 (install with pyenv) and uv on your local machine.
+
+Install uv if you haven't already:
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
 
 Clone the SEAD Clearinghouse import repository into a new folder and setup the local environment:
 
 ```bash
 git clone git@github.com:humlab-sead/sead_clearinghouse_import
 cd sead_clearinghouse_import
-poetry install
+uv sync
 ```
 ### Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,37 @@
-[tool.poetry]
+[project]
 name = "sead-clearinghouse-import"
 version = "0.1.0"
 description = "SEAD Clearing House Import System"
-authors = ["Roger Mähler <roger.mahler@hotmail.com>"]
+authors = [{name = "Roger Mähler", email = "roger.mahler@hotmail.com"}]
 readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "numpy>=1.26.2",
+    "pandas>=2.1.4",
+    "psycopg2-binary>=2.9.9",
+    "xlrd>=2.0.1",
+    "lxml>=4.9.4",
+    "click>=8.1.7",
+    "loguru>=0.7.2",
+    "python-dotenv>=1.0.0",
+    "openpyxl>=3.1.2",
+    "sqlalchemy>=2.0.23",
+    "jinja2>=3.1.2",
+    "xlsxwriter>=3.1.9",
+    "pyaml>=24.9.0",
+    "xlsx2csv>=0.8.4",
+]
 
-[tool.poetry.dependencies]
-python = "3.12.*"
-numpy = "^1.26.2"
-pandas = "^2.1.4"
-psycopg2 = "^2.9.9"
-xlrd = "^2.0.1"
-lxml = "^4.9.4"
-click = "^8.1.7"
-loguru = "^0.7.2"
-python-dotenv = "^1.0.0"
-openpyxl = "^3.1.2"
-sqlalchemy = "^2.0.23"
-jinja2 = "^3.1.2"
-xlsxwriter = "^3.1.9"
-pyaml = "^24.9.0"
-xlsx2csv = "^0.8.4"
+[project.optional-dependencies]
+dev = [
+    "pylint>=3.0.3",
+    "pytest>=7.4.3",
+    "pytest-cov>=4.1.0",
+    "black>=24.10.0",
+    "isort>=5.13.0",
+]
 
-
-[tool.poetry.group.dev.dependencies]
-pylint = "^3.0.3"
-pytest = "^7.4.3"
-black = "^24.10.0"
-
-[tool.poetry.scripts]
+[project.scripts]
 process-submission = "importer.scripts.process_submission:import_file"
 import-excel = "importer.scripts.process_submission:import_file"
 
@@ -59,5 +62,8 @@ float_to_top = true
 src_paths = ["importer", "tests"]
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["importer"]


### PR DESCRIPTION
Transition from Poetry to uv for package management in the SEAD Clearinghouse Import project. Update configuration files, documentation, and Makefile commands accordingly. Include instructions for setting up the AI agent.